### PR TITLE
fix apiUrl for blockscout to pass hardhat verify command

### DIFF
--- a/src/pages/build/tutorials/deploying-a-smart-contract/hardhat.mdx
+++ b/src/pages/build/tutorials/deploying-a-smart-contract/hardhat.mdx
@@ -96,7 +96,7 @@ module.exports = {
         network: "inksepolia",
         chainId: 763373,
         urls: {
-          apiURL: "https://explorer-sepolia.inkonchain.com/api/v2",
+          apiURL: "https://explorer-sepolia.inkonchain.com/api",
           browserURL: "https://explorer-sepolia.inkonchain.com/",
         },
       },


### PR DESCRIPTION
`npx hardhat verify --network inksepolia <address> ` with `api/v2` returns error

> The HTTP server response is not ok. Status code: 404 Response text: {"message":"Not found","result":null,"status":"0"}

without it, command works properly

I use "hardhat": "^2.22.17"